### PR TITLE
Add Jupyter server utilities

### DIFF
--- a/jupyter_server/.env.example
+++ b/jupyter_server/.env.example
@@ -1,0 +1,9 @@
+# Jira configuration
+JIRA_URL=https://your-jira-instance.atlassian.net
+JIRA_USER=your-email@example.com
+JIRA_API_TOKEN=your-api-token
+
+# Bitbucket configuration
+BITBUCKET_URL=https://api.bitbucket.org
+BITBUCKET_USERNAME=your-username
+BITBUCKET_PASSWORD=your-app-password

--- a/jupyter_server/.gitignore
+++ b/jupyter_server/.gitignore
@@ -1,0 +1,3 @@
+.env
+api_map.md
+__pycache__/

--- a/jupyter_server/README.md
+++ b/jupyter_server/README.md
@@ -1,0 +1,42 @@
+# Jupyter Server for Atlassian Python API
+
+This directory provides utilities for running client notebooks that interact with Jira and Bitbucket using the [`atlassian-python-api`](https://github.com/Cazador0/atlassian-python-api).
+
+## Setup
+
+1. Create and activate a Python virtual environment.
+2. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+# install the library from the repository root
+pip install -e ..
+```
+
+3. Copy `.env.example` to `.env` and fill in your connection details.
+
+4. Launch Jupyter:
+
+```bash
+jupyter notebook
+```
+
+## Adding a Client Notebook
+
+Run the helper script with the desired client name:
+
+```bash
+python init_client.py CLIENT_NAME
+```
+
+This creates `notebooks/CLIENT_NAME/CLIENT_NAME.ipynb` from the template.
+
+## Generating an API Feature Map
+
+To list available methods on the `Jira` and `Bitbucket` classes, run:
+
+```bash
+python list_features.py
+```
+
+The results will be written to `api_map.md` in this directory.

--- a/jupyter_server/init_client.py
+++ b/jupyter_server/init_client.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Create a notebook folder for a new client."""
+from pathlib import Path
+import shutil
+import sys
+
+ROOT = Path(__file__).resolve().parent
+TEMPLATE = ROOT / "templates" / "client_template.ipynb"
+NOTEBOOK_ROOT = ROOT / "notebooks"
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: init_client.py <client_name>")
+        return
+    name = sys.argv[1]
+    target_dir = NOTEBOOK_ROOT / name
+    target_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(TEMPLATE, target_dir / f"{name}.ipynb")
+    print(f"Created notebook {target_dir / f'{name}.ipynb'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/jupyter_server/list_features.py
+++ b/jupyter_server/list_features.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Generate a markdown file listing Jira and Bitbucket API methods."""
+
+import inspect
+from pathlib import Path
+from atlassian import Jira, Bitbucket
+
+OUTPUT = Path(__file__).resolve().parent / "api_map.md"
+
+
+def is_public(name: str) -> bool:
+    return not name.startswith("_")
+
+
+def get_methods(cls):
+    return sorted(name for name, member in inspect.getmembers(cls, inspect.isfunction) if is_public(name))
+
+
+def main():
+    jira_methods = get_methods(Jira)
+    bitbucket_methods = get_methods(Bitbucket)
+    with OUTPUT.open("w") as fh:
+        fh.write("# API Feature Map\n\n")
+        fh.write("## Jira\n")
+        for m in jira_methods:
+            fh.write(f"- `{m}`\n")
+        fh.write("\n## Bitbucket\n")
+        for m in bitbucket_methods:
+            fh.write(f"- `{m}`\n")
+    print(f"API map written to {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/jupyter_server/requirements.txt
+++ b/jupyter_server/requirements.txt
@@ -1,0 +1,3 @@
+jupyter
+atlassian-python-api>=4.0.4
+python-dotenv

--- a/jupyter_server/templates/client_template.ipynb
+++ b/jupyter_server/templates/client_template.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Client Notebook\n",
+    "Use the Atlassian Python API to interact with Jira and Bitbucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "import os\n",
+    "from atlassian import Jira, Bitbucket\n",
+    "load_dotenv()\n",
+    "jira = Jira(os.getenv('JIRA_URL'), username=os.getenv('JIRA_USER'), password=os.getenv('JIRA_API_TOKEN'))\n",
+    "bitbucket = Bitbucket(os.getenv('BITBUCKET_URL'), username=os.getenv('BITBUCKET_USERNAME'), password=os.getenv('BITBUCKET_PASSWORD'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example calls\n",
+    "jira.projects()\n",
+    "bitbucket.project_list()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- add utilities for local Jupyter notebooks
- provide init script and feature listing helper
- provide example environment file and template notebook

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6860347250548322bcf330dff8f14018